### PR TITLE
resolves #4

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,6 @@
  */
 
 module.exports = function isGitUrl(str) {
-  var re = /(?:git|ssh|https?|git@[\w\.]+):(?:\/\/)?[\w\.@:\/~_-]+\.git\/?$/;
+  var re = /(?:git|ssh|https?|git@[\w\.]+):(?:\/\/)?[\w\.@:\/~_-]+\.git(?:\/?|\#[a-z0-9\.]+?)$/;
   return re.test(str);
 };

--- a/package.json
+++ b/package.json
@@ -32,5 +32,8 @@
     "regexp",
     "test",
     "url"
-  ]
+  ],
+  "devDependencies": {
+    "mocha": "^2.2.5"
+  }
 }

--- a/test.js
+++ b/test.js
@@ -9,6 +9,8 @@ var assert = require('assert');
 var isGitUrl = require('./');
 
 var validURLs = [
+  'git://github.com/ember-cli/ember-cli.git#v0.1.0',
+  'git://github.com/ember-cli/ember-cli.git#ff786f9f',
   'git@github.com:user/project.git',
   'git@github.com:user/some-project.git',
   'git@github.com:user/some_project.git',
@@ -54,13 +56,13 @@ var invalidURLs = [
 
 
 validURLs.forEach(function(url, i) {
-  it('git URL: #' + i++, function () {
+  it('git URL: #' + (i++) + ' - ' + url, function () {
     assert(isGitUrl(url) === true);
   });
 });
 
 invalidURLs.forEach(function(url, i) {
-  it('not a git URL: #' + i++, function () {
+  it('not a git #' + (i++) + ' - ' + url, function () {
     assert(isGitUrl(url) === false);
   });
 });


### PR DESCRIPTION
resolves #4

more use cases? i guess it would also allow adding `#foobar` for all other urls like

```
git://host.xz/~user/path/to/repo.git#v1.2.3
git@github.com:user/some-project.git#v1.2.3
```

which im not sure is correct?

/cc @quaertym 