### PR TITLE
Fix and test for git url with branch name

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,6 @@
  */
 
 module.exports = function isGitUrl(str) {
-  var re = /(?:git|ssh|https?|git@[\w\.]+):(?:\/\/)?[\w\.@:\/~_-]+\.git(?:\/?|\#[a-z0-9\.]+?)$/;
+  var re = /(?:git|ssh|https?|git@[\w\.]+):(?:\/\/)?[\w\.@:\/~_-]+\.git(?:\/?|\#[\d\w\.\-_]+?)$/;
   return re.test(str);
 };

--- a/test.js
+++ b/test.js
@@ -12,6 +12,10 @@ var isGitUrl = require('./');
 var validURLs = [
   'git://github.com/ember-cli/ember-cli.git#v0.1.0',
   'git://github.com/ember-cli/ember-cli.git#ff786f9f',
+  'git://github.com/ember-cli/ember-cli.git#master',
+  'git://github.com/ember-cli/ember-cli.git#gh-pages',
+  'git://github.com/ember-cli/ember-cli.git#quick_fix',
+  'git://github.com/ember-cli/ember-cli.git#Quick-Fix',
   'git@github.com:user/project.git',
   'git@github.com:user/some-project.git',
   'git@github.com:user/some_project.git',


### PR DESCRIPTION
URLs with branch names(_with dash or underscore in the middle_) should also be considered as valid:
```
git://github.com/ember-cli/ember-cli.git#gh-pages
```