### PR TITLE
eslint complains "no-useless-escape"

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,6 @@
  */
 
 module.exports = function isGitUrl(str) {
-  var regex = /(?:git|ssh|https?|git@[-\w.]+):(\/\/)?(.*?)(\.git)(\/?|\#[-\d\w._]+?)$/;
+  var regex = /(?:git|ssh|https?|git@[-\w.]+):(\/\/)?(.*?)(\.git)(\/?|#[-\d\w._]+?)$/;
   return regex.test(str);
 };


### PR DESCRIPTION
eslint says: `Unnecessary escape character: \#  no-useless-escape. `

Seems like a valid error.

Creating a pull request w/o testing in case someone can check it before I get a chance.

